### PR TITLE
Change palette to white & blue with glow

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,21 +4,23 @@
   --color-surface: rgba(240, 248, 255, 1);
   --color-text: rgba(0, 51, 102, 1);
   --color-text-secondary: rgba(148, 163, 184, 1);
-  --color-primary: rgba(0, 123, 255, 1);
-  --color-primary-hover: rgba(0, 86, 179, 1);
-  --color-primary-active: rgba(0, 70, 140, 1);
-  --color-secondary: rgba(0, 123, 255, 0.12);
-  --color-secondary-hover: rgba(0, 123, 255, 0.2);
-  --color-secondary-active: rgba(0, 123, 255, 0.25);
+  --accent-blue: #2563eb;
+  --accent-blue-hover: #1e40af;
+  --color-primary: var(--accent-blue);
+  --color-primary-hover: var(--accent-blue-hover);
+  --color-primary-active: #193fa1;
+  --color-secondary: rgba(37, 99, 235, 0.12);
+  --color-secondary-hover: rgba(37, 99, 235, 0.2);
+  --color-secondary-active: rgba(37, 99, 235, 0.25);
   --color-border: rgba(0, 51, 102, 0.2);
   --color-btn-primary-text: rgba(255, 255, 255, 1);
   --color-card-border: rgba(0, 51, 102, 0.12);
   --color-card-border-inner: rgba(0, 51, 102, 0.12);
   --color-error: rgba(192, 21, 47, 1);
-  --color-success: rgba(0, 123, 255, 1);
+  --color-success: var(--accent-blue);
   --color-warning: rgba(168, 75, 47, 1);
   --color-info: rgba(98, 108, 113, 1);
-  --color-focus-ring: rgba(0, 123, 255, 0.4);
+  --color-focus-ring: rgba(37, 99, 235, 0.4);
   --color-select-caret: rgba(245, 245, 245, 0.8);
 
   /* Common style patterns */
@@ -30,7 +32,7 @@
   --select-caret-dark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23f5f5f5' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
 
   /* RGB versions for opacity control */
-  --color-success-rgb: 0, 123, 255;
+  --color-success-rgb: 37, 99, 235;
   --color-error-rgb: 192, 21, 47;
   --color-warning-rgb: 168, 75, 47;
   --color-info-rgb: 98, 108, 113;
@@ -107,18 +109,18 @@
     --color-surface: rgba(240, 248, 255, 1);
     --color-text: rgba(0, 51, 102, 1);
     --color-text-secondary: rgba(148, 163, 184, 0.7);
-    --color-primary: rgba(0, 123, 255, 1);
-    --color-primary-hover: rgba(0, 86, 179, 1);
-    --color-primary-active: rgba(0, 70, 140, 1);
+    --color-primary: var(--accent-blue);
+    --color-primary-hover: var(--accent-blue-hover);
+    --color-primary-active: #193fa1;
     --color-secondary: rgba(255, 255, 255, 0.15);
     --color-secondary-hover: rgba(255, 255, 255, 0.25);
     --color-secondary-active: rgba(255, 255, 255, 0.3);
     --color-border: rgba(255, 255, 255, 0.3);
     --color-error: rgba(255, 84, 89, 1);
-    --color-success: rgba(0, 123, 255, 1);
+    --color-success: var(--accent-blue);
     --color-warning: rgba(230, 129, 97, 1);
     --color-info: rgba(167, 169, 169, 1);
-    --color-focus-ring: rgba(0, 123, 255, 0.4);
+    --color-focus-ring: rgba(37, 99, 235, 0.4);
     --color-btn-primary-text: rgba(255, 255, 255, 1);
     --color-card-border: rgba(255, 255, 255, 0.2);
     --color-card-border-inner: rgba(255, 255, 255, 0.15);
@@ -137,7 +139,7 @@
     --select-caret-dark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23f5f5f5' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
 
     /* RGB versions for dark mode */
-    --color-success-rgb: 0, 123, 255;
+    --color-success-rgb: 37, 99, 235;
     --color-error-rgb: 255, 84, 89;
     --color-warning-rgb: 230, 129, 97;
     --color-info-rgb: 167, 169, 169;
@@ -150,18 +152,18 @@
   --color-surface: rgba(38, 40, 40, 1);
   --color-text: rgba(0, 51, 102, 1);
   --color-text-secondary: rgba(148, 163, 184, 0.7);
-  --color-primary: rgba(0, 123, 255, 1);
-  --color-primary-hover: rgba(0, 86, 179, 1);
-  --color-primary-active: rgba(0, 70, 140, 1);
+  --color-primary: var(--accent-blue);
+  --color-primary-hover: var(--accent-blue-hover);
+  --color-primary-active: #193fa1;
   --color-secondary: rgba(255, 255, 255, 0.15);
   --color-secondary-hover: rgba(255, 255, 255, 0.25);
   --color-secondary-active: rgba(255, 255, 255, 0.3);
   --color-border: rgba(255, 255, 255, 0.3);
   --color-error: rgba(255, 84, 89, 1);
-  --color-success: rgba(0, 123, 255, 1);
+  --color-success: var(--accent-blue);
   --color-warning: rgba(230, 129, 97, 1);
   --color-info: rgba(167, 169, 169, 1);
-  --color-focus-ring: rgba(0, 123, 255, 0.4);
+  --color-focus-ring: rgba(37, 99, 235, 0.4);
   --color-btn-primary-text: rgba(255, 255, 255, 1);
   --color-card-border: rgba(255, 255, 255, 0.15);
   --color-card-border-inner: rgba(255, 255, 255, 0.15);
@@ -179,7 +181,7 @@
   --select-caret-dark: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23f5f5f5' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
 
   /* RGB versions for dark mode */
-  --color-success-rgb: 0, 123, 255;
+  --color-success-rgb: 37, 99, 235;
   --color-error-rgb: 255, 84, 89;
   --color-warning-rgb: 230, 129, 97;
   --color-info-rgb: 167, 169, 169;
@@ -190,24 +192,24 @@
   --color-surface: rgba(240, 248, 255, 1);
   --color-text: rgba(0, 51, 102, 1);
   --color-text-secondary: rgba(148, 163, 184, 1);
-  --color-primary: rgba(0, 123, 255, 1);
-  --color-primary-hover: rgba(0, 86, 179, 1);
-  --color-primary-active: rgba(0, 70, 140, 1);
-  --color-secondary: rgba(0, 123, 255, 0.12);
-  --color-secondary-hover: rgba(0, 123, 255, 0.2);
-  --color-secondary-active: rgba(0, 123, 255, 0.25);
+  --color-primary: var(--accent-blue);
+  --color-primary-hover: var(--accent-blue-hover);
+  --color-primary-active: #193fa1;
+  --color-secondary: rgba(37, 99, 235, 0.12);
+  --color-secondary-hover: rgba(37, 99, 235, 0.2);
+  --color-secondary-active: rgba(37, 99, 235, 0.25);
   --color-border: rgba(0, 51, 102, 0.2);
   --color-btn-primary-text: rgba(255, 255, 255, 1);
   --color-card-border: rgba(0, 51, 102, 0.12);
   --color-card-border-inner: rgba(0, 51, 102, 0.12);
   --color-error: rgba(192, 21, 47, 1);
-  --color-success: rgba(0, 123, 255, 1);
+  --color-success: var(--accent-blue);
   --color-warning: rgba(168, 75, 47, 1);
   --color-info: rgba(98, 108, 113, 1);
-  --color-focus-ring: rgba(0, 123, 255, 0.4);
+  --color-focus-ring: rgba(37, 99, 235, 0.4);
 
   /* RGB versions for light mode */
-  --color-success-rgb: 0, 123, 255;
+  --color-success-rgb: 37, 99, 235;
   --color-error-rgb: 192, 21, 47;
   --color-warning-rgb: 168, 75, 47;
   --color-info-rgb: 98, 108, 113;
@@ -485,12 +487,12 @@ select.form-control {
 
 .status--success {
   background-color: rgba(
-    var(--color-success-rgb, 0, 123, 255),
+    var(--color-success-rgb, 37, 99, 235),
     var(--status-bg-opacity)
   );
   color: var(--color-success);
   border: 1px solid
-    rgba(var(--color-success-rgb, 0, 123, 255), var(--status-border-opacity));
+    rgba(var(--color-success-rgb, 37, 99, 235), var(--status-border-opacity));
 }
 
 .status--error {
@@ -691,14 +693,15 @@ body {
 }
 
 .nav-dot:hover {
-    background-color: rgba(0, 123, 255, 0.5);
+    background-color: rgba(37, 99, 235, 0.5);
     transform: scale(1.2);
 }
 
 .nav-dot.active {
-    background-color: #007BFF;
+    background-color: var(--accent-blue);
+    box-shadow: 0 0 6px rgba(37, 99, 235, 0.6);
     border-color: var(--color-background);
-    box-shadow: 0 0 0 2px #007BFF;
+    box-shadow: 0 0 0 2px var(--accent-blue), 0 0 8px rgba(37, 99, 235, 0.6);
 }
 
 /* Progress Bar */
@@ -714,7 +717,8 @@ body {
 
 .progress-fill {
     height: 100%;
-    background-color: #007BFF;
+    background-color: var(--accent-blue);
+    box-shadow: 0 0 6px rgba(37, 99, 235, 0.6);
     width: 0%;
     transition: width 0.3s ease;
 }
@@ -772,9 +776,10 @@ body {
 .hero-title {
     font-size: 4.5rem;
     font-weight: 200;
-    color: #007BFF;
+    color: var(--accent-blue);
     margin-bottom: 1rem;
     letter-spacing: -0.03em;
+    text-shadow: 0 0 6px rgba(37, 99, 235, 0.5);
 }
 
 .hero-subtitle {
@@ -798,7 +803,7 @@ body {
 .stat-number {
     font-size: 3rem;
     font-weight: 300;
-    color: #007BFF;
+    color: var(--accent-blue);
     margin-bottom: 0.5rem;
 }
 
@@ -871,12 +876,12 @@ body {
 
 .achievement-card:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 20px rgba(0, 123, 255, 0.1);
-    border-color: #007BFF;
+    box-shadow: 0 4px 20px rgba(37, 99, 235, 0.1);
+    border-color: var(--accent-blue);
 }
 
 .achievement-card i {
-    color: #007BFF;
+    color: var(--accent-blue);
     width: 24px;
     height: 24px;
 }
@@ -900,7 +905,8 @@ body {
     top: 0;
     bottom: 0;
     width: 2px;
-    background-color: #007BFF;
+    background-color: var(--accent-blue);
+    box-shadow: 0 0 6px rgba(37, 99, 235, 0.6);
     transform: translateX(-50%);
 }
 
@@ -927,11 +933,12 @@ body {
     left: 50%;
     width: 16px;
     height: 16px;
-    background-color: #007BFF;
+    background-color: var(--accent-blue);
+    box-shadow: 0 0 6px rgba(37, 99, 235, 0.6);
     border-radius: 50%;
     transform: translateX(-50%);
     border: 4px solid var(--color-background);
-    box-shadow: 0 0 0 2px #007BFF;
+    box-shadow: 0 0 0 2px var(--accent-blue), 0 0 8px rgba(37, 99, 235, 0.6);
 }
 
 .timeline-content {
@@ -945,7 +952,7 @@ body {
 
 .timeline-date {
     font-size: 0.9rem;
-    color: #007BFF;
+    color: var(--accent-blue);
     font-weight: 600;
     margin-bottom: 0.5rem;
 }
@@ -988,7 +995,8 @@ body {
 
 .problem-category {
     display: inline-block;
-    background-color: #007BFF;
+    background-color: var(--accent-blue);
+    box-shadow: 0 0 6px rgba(37, 99, 235, 0.6);
     color: var(--color-btn-primary-text);
     padding: 0.5rem 1rem;
     border-radius: 20px;
@@ -1043,12 +1051,12 @@ body {
 
 .point-item:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 25px rgba(0, 123, 255, 0.15);
-    border-color: #007BFF;
+    box-shadow: 0 6px 25px rgba(37, 99, 235, 0.15);
+    border-color: var(--accent-blue);
 }
 
 .point-item i {
-    color: #007BFF;
+    color: var(--accent-blue);
     width: 32px;
     height: 32px;
     flex-shrink: 0;
@@ -1070,7 +1078,8 @@ body {
     align-items: center;
     gap: 0.5rem;
     padding: 1rem 2rem;
-    background-color: #007BFF;
+    background-color: var(--accent-blue);
+    box-shadow: 0 0 6px rgba(37, 99, 235, 0.6);
     color: var(--color-btn-primary-text);
     border: none;
     border-radius: 50px;
@@ -1078,13 +1087,13 @@ body {
     font-weight: 500;
     cursor: pointer;
     transition: all 0.3s ease;
-    box-shadow: 0 4px 15px rgba(0, 123, 255, 0.3);
+    box-shadow: 0 4px 15px rgba(37, 99, 235, 0.3);
 }
 
 .btn-back-to-top:hover {
-    background-color: #0056b3;
+    background-color: var(--accent-blue-hover);
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(0, 123, 255, 0.4);
+    box-shadow: 0 6px 20px rgba(37, 99, 235, 0.4);
 }
 
 .btn-back-to-top i {


### PR DESCRIPTION
## Summary
- switch global color variables to bright palette with blue accents
- add subtle blue glow effects to interactive UI elements

## Testing
- `node app.js` *(fails: document is not defined)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fe52be69c832d83bc8a02a3874a47