### PR TITLE
Enable floating 3D shapes in presentation

### DIFF
--- a/background.js
+++ b/background.js
@@ -17,15 +17,24 @@ function initBackground3D() {
     container.appendChild(renderer.domElement);
 
     const objects = [];
-    const geometry = new THREE.SphereGeometry(1, 16, 16);
 
-    for (let i = 0; i < 20; i++) {
+    const geometries = [
+        new THREE.SphereGeometry(1, 16, 16),
+        new THREE.TorusGeometry(1, 0.4, 16, 32),
+        new THREE.BoxGeometry(1.4, 1.4, 1.4),
+        new THREE.ConeGeometry(1, 1.5, 4)
+    ];
+
+    for (let i = 0; i < 25; i++) {
         const glow = Math.random() > 0.7;
         const material = new THREE.MeshPhongMaterial({
-            color: 0x3498db,
+            color: 0x3399ff,
             emissive: glow ? 0x66aaff : 0x000000,
-            shininess: 50,
+            shininess: 80,
+            transparent: true,
+            opacity: 0.7
         });
+        const geometry = geometries[Math.floor(Math.random() * geometries.length)];
         const mesh = new THREE.Mesh(geometry, material);
         mesh.position.set((Math.random() - 0.5) * 60, (Math.random() - 0.5) * 60, (Math.random() - 0.5) * 60);
         mesh.userData.velocity = new THREE.Vector3((Math.random() - 0.5) * 0.1, (Math.random() - 0.5) * 0.1, (Math.random() - 0.5) * 0.1);
@@ -33,9 +42,10 @@ function initBackground3D() {
         objects.push(mesh);
     }
 
-    const light = new THREE.PointLight(0xffffff, 1);
-    light.position.set(0, 0, 60);
-    scene.add(light);
+    const pointLight = new THREE.PointLight(0xffffff, 1);
+    pointLight.position.set(0, 0, 60);
+    scene.add(pointLight);
+    scene.add(new THREE.AmbientLight(0xffffff, 0.4));
 
     function animate() {
         requestAnimationFrame(animate);

--- a/style.css
+++ b/style.css
@@ -725,6 +725,8 @@ body {
 
 /* Main Presentation Container */
 .presentation {
+    position: relative;
+    z-index: 1;
     scroll-snap-type: y mandatory;
     overflow-y: scroll;
     height: 100vh;
@@ -1296,7 +1298,7 @@ body {
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: -1;
+    z-index: 0;
     pointer-events: none;
     overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- ensure the 3D canvas is visible behind slides
- raise presentation layer to float above the background
- generate a variety of transparent blue shapes
- add ambient lighting for better appearance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fef0e3500832da20248877e987caf